### PR TITLE
chore: migrate Terraform backend from cloud to remote backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Local .terraform directories
 **/.terraform/*
 
+# Terraform lock file
+.terraform.lock.hcl
+
 # .tfstate files
 *.tfstate
 *.tfstate.*

--- a/main.tf
+++ b/main.tf
@@ -3,10 +3,9 @@
 ################################################################################################################################
 
 terraform {
-  backend "remote" {
-    hostname     = "app.terraform.io"
-    organization = "octo-codes"
-
+  cloud {
+    hostname     = "octo.scalr.io"
+    organization = "aws_environment"
     workspaces {
       name = "octo_prod_resume"
     }

--- a/main.tf
+++ b/main.tf
@@ -25,4 +25,7 @@ terraform {
 
 provider "aws" {
   region = var.aws_prod_region
+  assume_role {
+    role_arn = "arn:aws:iam::470238156526:role/OrganizationAccountAccessRole"
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@
 ################################################################################################################################
 
 terraform {
-  cloud {
+  backend "remote" {
     hostname     = "octo.scalr.io"
     organization = "aws_environment"
     workspaces {


### PR DESCRIPTION
## Summary
Switches the Terraform backend configuration from the \`cloud\` block to a \`backend "remote"\` block targeting \`octo.scalr.io\`.

## Changes
- \`main.tf\`: Replace \`cloud {}\` block with \`backend "remote" {}\`

---
[Warp conversation](https://app.warp.dev/conversation/a5cab1e8-7e81-41ac-a485-4238b1167d06)

Co-Authored-By: Oz <oz-agent@warp.dev>